### PR TITLE
ci: add SwiftLint and SonarCloud scanning to workflows

### DIFF
--- a/.github/workflows/quality-report.yml
+++ b/.github/workflows/quality-report.yml
@@ -1,20 +1,15 @@
-name: iOS Pull Request
+name: Run Quality Report
 
 on:
-  pull_request:
-    types: [ opened, reopened, synchronize, ready_for_review ]
+  push:
     branches: [ main ]
-    
-concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  workflow_dispatch:
 
 jobs:
   build:
-    name: Build and Test default scheme using any available iPhone simulator
-    if: github.event.pull_request.draft == false
-    runs-on: macos-13
-
+    name: Run Quality Report
+    runs-on: mobile-ios
+    
     steps:
       - name: Add path globally
         run: echo "/usr/local/bin" >> $GITHUB_PATH
@@ -23,12 +18,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           lfs: 'true'
-          fetch-depth: 0
           
-      - name: Run Linter
-        run: |
-          swiftlint --strict
-            
       - name: Build and Test
         run: |
           xcodebuild -scheme Networking-Package test -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" \
@@ -44,18 +34,7 @@ jobs:
           
           sonar-scanner \
             -Dsonar.token=$SONAR_TOKEN \
-            -Dsonar.coverageReportPaths="Coverage.xml" \
-            -Dsonar.pullrequest.key=$pull_number \
-            -Dsonar.pullrequest.branch=${{github.head_ref}} \
-            -Dsonar.pullrequest.base=${{github.base_ref}}
+            -Dsonar.coverageReportPaths="Coverage.xml"
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
-      - name: Check SonarCloud Results
-        uses: sonarsource/sonarqube-quality-gate-action@master
-        # Force to fail step after specific time
-        timeout-minutes: 5
-        env:
-         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          

--- a/.github/workflows/quality-report.yml
+++ b/.github/workflows/quality-report.yml
@@ -30,8 +30,6 @@ jobs:
           
           brew install sonar-scanner
           
-          pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
-          
           sonar-scanner \
             -Dsonar.token=$SONAR_TOKEN \
             -Dsonar.coverageReportPaths="Coverage.xml"

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,49 @@
+disabled_rules:
+- cyclomatic_complexity
+- multiple_closures_with_trailing_closure
+- todo
+
+analyzer_rules:
+- unused_import
+
+opt_in_rules:
+- sorted_imports
+- strong_iboutlet
+- private_action
+- private_outlet
+
+trailing_whitespace:
+  ignores_empty_lines: true
+vertical_whitespace:
+  max_empty_lines: 2
+line_length:
+  warning: 180
+  ignores_urls: true
+  ignores_interpolated_strings: true
+large_tuple:
+  warning: 3
+  error: 4
+identifier_name:
+  max_length:
+   warning: 60
+  min_length:
+    warning: 1
+    error: 1
+  allowed_symbols: ["_"]
+type_name:
+  allowed_symbols: ["_"]
+  max_length:
+    warning: 50
+nesting:
+  type_level: 2
+
+custom_rules:
+  todo_format:
+    match_kinds: comment
+    severity: warning
+    message: >
+        TODO comments must have a valid ticket number raised in Jira.
+        Please use the format:
+        // TODO: DCMAW-000
+    regex: "(?i)(todo(?!(.*dcmaw-\\d{2,})))"
+    

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,15 @@
+sonar.projectKey=di-mobile-ios-networking
+sonar.projectName=di-mobile-ios-networking
+sonar.pullrequest.github.repository=alphagov/di-mobile-ios-networking
+sonar.projectVersion=1.0
+
+sonar.organization=gds-document-checking
+
+sonar.sources=Sources
+sonar.tests=Tests
+
+sonar.language=swift
+sonar.sourceEncoding=UTF-8
+sonar.pullrequest.provider=github
+
+sonar.host.url=https://sonarcloud.io

--- a/xccov-to-sonarqube-generic.sh
+++ b/xccov-to-sonarqube-generic.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+function convert_xccov_to_xml {
+  sed -n                                                                                       \
+      -e '/:$/s/&/\&amp;/g;s/^\(.*\):$/  <file path="\1">/p'                                   \
+      -e 's/^ *\([0-9][0-9]*\): 0.*$/    <lineToCover lineNumber="\1" covered="false"\/>/p'    \
+      -e 's/^ *\([0-9][0-9]*\): [1-9].*$/    <lineToCover lineNumber="\1" covered="true"\/>/p' \
+      -e 's/^$/  <\/file>/p'
+}
+
+function xccov_to_generic {
+  local xcresult="$1"
+
+  echo '<coverage version="1">'
+  xcrun xccov view --archive "$xcresult" | convert_xccov_to_xml
+  echo '</coverage>'
+}
+
+function check_xcode_version() {
+  local major=${1:-0} minor=${2:-0}
+  return $(( (major >= 14) || (major == 13 && minor >= 3) ))
+}
+
+if ! xcode_version="$(xcodebuild -version | sed -n '1s/^Xcode \([0-9.]*\)$/\1/p')"; then
+  echo 'Failed to get Xcode version' 1>&2
+  exit 1
+elif check_xcode_version ${xcode_version//./ }; then
+  echo "Xcode version '$xcode_version' not supported, version 13.3 or above is required" 1>&2;
+  exit 1
+fi
+
+xcresult="$1"
+if [[ $# -ne 1 ]]; then
+  echo "Invalid number of arguments. Expecting 1 path matching '*.xcresult'"
+  exit 1
+elif [[ ! -d $xcresult ]]; then
+  echo "Path not found: $xcresult" 1>&2;
+  exit 1
+elif [[ $xcresult != *".xcresult"* ]]; then
+  echo "Expecting input to match '*.xcresult', got: $xcresult" 1>&2;
+  exit 1
+fi
+
+xccov_to_generic "$xcresult"


### PR DESCRIPTION
# ci: added SonarQube scanning to pull requests

DCMAW-6444: Add SonarCloud scanning to all packages

SonarCloud is used to enforce code quality standards and detect security hotspots in our code.
It should be run against all of our packages (including new modules we have created).

I have set this up using the Sonar recommended `xccov` approach:
https://github.com/SonarSource/sonar-scanning-examples/tree/master/swift-coverage

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [ ] ~~Met all accessibility requirements?~~
    - [ ] ~~Checked dynamic type sizes are applied~~
    - [ ] ~~Checked VoiceOver can navigate your new code~~
    - [ ] ~~Checked a user can navigate only using a keyboard around your new code~~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
